### PR TITLE
mcuxhelloworld: Make mcuxhelloworld installable into an image

### DIFF
--- a/recipes-mcuxhelloworld/mcuxhelloworld/mcuxhelloworld_1.0.bb
+++ b/recipes-mcuxhelloworld/mcuxhelloworld/mcuxhelloworld_1.0.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "M4 firmware Hello World from Yocto"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-inherit deploy cmake native
+inherit deploy cmake
 
 DEPENDS += "mcuxpresso-native"
 DEPENDS += "gcc-arm-none-eabi-native"


### PR DESCRIPTION
mcuxhelloworld is not a native recipe so remove the "native" inherit. This makes is possible to installable mcuxhelloworld into an image.